### PR TITLE
Fixed a name clash with libc++ bundled with clang. The offending file is...

### DIFF
--- a/src/zmqpp/inet.hpp
+++ b/src/zmqpp/inet.hpp
@@ -71,12 +71,10 @@ inline uint64_t swap_if_needed(uint64_t const value_to_check)
 /*!
  * 64 bit version of the htons/htonl
  *
- * I've used the name htonll to try and keep with the htonl naming scheme.
- *
  * \param hostlonglong unsigned 64 bit host order integer
  * \return unsigned 64 bit network order integer
  */
-inline uint64_t htonll(uint64_t const hostlonglong)
+inline uint64_t htonl64(uint64_t const hostlonglong)
 {
 	return zmqpp::swap_if_needed(hostlonglong);
 }
@@ -84,12 +82,10 @@ inline uint64_t htonll(uint64_t const hostlonglong)
 /*!
  * 64 bit version of the ntohs/ntohl
  *
- * I've used the name htonll to try and keep with the htonl naming scheme.
- *
  * \param networklonglong unsigned 64 bit network order integer
  * \return unsigned 64 bit host order integer
  */
-inline uint64_t ntohll(uint64_t const networklonglong)
+inline uint64_t ntohl64(uint64_t const networklonglong)
 {
 	return zmqpp::swap_if_needed(networklonglong);
 }
@@ -142,7 +138,7 @@ inline double htond(double value)
 
 	uint64_t temp;
 	memcpy(&temp, &value, sizeof(uint64_t));
-	temp = zmqpp::htonll(temp);
+	temp = zmqpp::htonl64(temp);
 	memcpy(&value, &temp, sizeof(uint64_t));
 
 	return value;
@@ -160,7 +156,7 @@ inline double ntohd(double value)
 
 	uint64_t temp;
 	memcpy(&temp, &value, sizeof(uint64_t));
-	temp = zmqpp::ntohll(temp);
+	temp = zmqpp::ntohl64(temp);
 	memcpy(&value, &temp, sizeof(uint64_t));
 
 	return value;

--- a/src/zmqpp/message.cpp
+++ b/src/zmqpp/message.cpp
@@ -138,7 +138,7 @@ void message::get(int64_t& integer, size_t const part) const
 	assert(sizeof(int64_t) == size(part));
 
 	uint64_t const* network_order = static_cast<uint64_t const*>(raw_data(part));
-	integer = static_cast<int64_t>(zmqpp::htonll(*network_order));
+	integer = static_cast<int64_t>(zmqpp::htonl64(*network_order));
 }
 
 void message::get(signal &sig, size_t const part) const
@@ -179,7 +179,7 @@ void message::get(uint64_t& unsigned_integer, size_t const part) const
 	assert(sizeof(uint64_t) == size(part));
 
 	uint64_t const* network_order = static_cast<uint64_t const*>(raw_data(part));
-	unsigned_integer = zmqpp::ntohll(*network_order);
+	unsigned_integer = zmqpp::ntohl64(*network_order);
 }
 
 void message::get(float& floating_point, size_t const part) const
@@ -237,7 +237,7 @@ message& message::operator<<(int32_t const integer)
 
 message& message::operator<<(int64_t const integer)
 {
-	uint64_t network_order = zmqpp::htonll(static_cast<uint64_t>(integer));
+	uint64_t network_order = zmqpp::htonl64(static_cast<uint64_t>(integer));
 	add_raw(reinterpret_cast<void const*>(&network_order), sizeof(uint64_t));
 
 	return *this;
@@ -272,7 +272,7 @@ message& message::operator<<(uint32_t const unsigned_integer)
 
 message& message::operator<<(uint64_t const unsigned_integer)
 {
-	uint64_t network_order = zmqpp::htonll(unsigned_integer);
+	uint64_t network_order = zmqpp::htonl64(unsigned_integer);
 	add_raw(reinterpret_cast<void const*>(&network_order), sizeof(uint64_t));
 
 	return *this;
@@ -342,7 +342,7 @@ void message::push_front(int32_t const integer)
 
 void message::push_front(int64_t const integer)
 {
-	uint64_t network_order = zmqpp::htonll(static_cast<uint64_t>(integer));
+	uint64_t network_order = zmqpp::htonl64(static_cast<uint64_t>(integer));
 	push_front(&network_order, sizeof(uint64_t));
 }
 
@@ -370,7 +370,7 @@ void message::push_front(uint32_t const unsigned_integer)
 
 void message::push_front(uint64_t const unsigned_integer)
 {
-	uint64_t network_order = zmqpp::htonll(unsigned_integer);
+	uint64_t network_order = zmqpp::htonl64(unsigned_integer);
 	push_front(&network_order, sizeof(uint64_t));
 }
 


### PR DESCRIPTION
... sys/_endian.h where htonll and ntohll are defined as macros.
